### PR TITLE
_include-component changes for cleaner source code

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,18 +1,18 @@
 <div id="breadcrumbs" style="margin-bottom: 2%;">
-    {% assign crumbs = page.url | remove:'/index.html' | split: '/' %}
+    {%- assign crumbs = page.url | remove:'/index.html' | split: '/' -%}
     <a href="/">Startseite</a>
-    {% for crumb in crumbs offset: 1 %}
-        {% capture crumb_text %}{{ crumb | replace:'-',' ' | remove:'.html' }}{% endcapture %}
-        {% if forloop.last %}
+    {%- for crumb in crumbs offset: 1 -%}
+        {%- capture crumb_text -%}{{ crumb | replace:'-',' ' | remove:'.html' }}{%- endcapture -%}
+        {%- if forloop.last -%}
             / {{ page.title }}
-        {% else %}
-            / <a href="{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' | replace:'without-plugin/','without-plugins/' }}{% endfor %}">
-            {% assign breadcrumb_words = crumb_text | split: ' ' %}
-            {% for filter_word in breadcrumb_words %}
-                {% if forloop.first %}
+        {%- else -%}
+            / <a href="{%- assign crumb_limit = forloop.index | plus: 1 -%}{%- for crumb in crumbs limit: crumb_limit -%}{{ crumb | append: '/' | replace:'without-plugin/','without-plugins/' }}{%- endfor -%}">
+            {%- assign breadcrumb_words = crumb_text | split: ' ' -%}
+            {%- for filter_word in breadcrumb_words -%}
+                {%- if forloop.first -%}
                     {{ filter_word | capitalize }}
-                {% else %}
-                    {% if 
+                {%- else -%}
+                    {%- if 
                     filter_word == 'der' or 
                     filter_word == 'die' or 
                     filter_word == 'das' or
@@ -27,15 +27,15 @@
                     filter_word == 'für' or 
                     filter_word == 'von' or
                     filter_word == 'bis' or
-                    filter_word == 'gestellte'%}
+                    filter_word == 'gestellte'-%}
                         {{ filter_word }}
-                    {% else %}
+                    {%- else -%}
                         {{ filter_word | capitalize }}
-                    {% endif %}
-                {% endif %}
-                {% unless forloop.last %} {% endunless %}
-            {% endfor %}
+                    {%- endif -%}
+                {%- endif -%}
+                {%- unless forloop.last -%} {%- endunless -%}
+            {%- endfor -%}
             </a>
-        {% endif %}
-    {% endfor %}
+        {%- endif -%}
+    {%- endfor -%}
 </div>

--- a/_includes/mobile-navigation.html
+++ b/_includes/mobile-navigation.html
@@ -1,67 +1,67 @@
 <div>
-    {% assign visited_urls = "" %}
-    {% assign sorted_pages = site.pages | where_exp: "item", "item.dir != '/'" | sort: 'order' %}
-    {% for page in sorted_pages %}
-      {% if page.order %}
-        {% if page.url != '/' %}
-          {% assign segments = page.url | split: '/' %}
-          {% assign depth = segments | size %}
-          {% if depth == 2 %}
-            {% unless visited_urls contains page.url %}
+    {%- assign visited_urls = "" -%}
+    {%- assign sorted_pages = site.pages | where_exp: "item", "item.dir != '/'" | sort: 'order' -%}
+    {%- for page in sorted_pages -%}
+      {%- if page.order -%}
+        {%- if page.url != '/' -%}
+          {%- assign segments = page.url | split: '/' -%}
+          {%- assign depth = segments | size -%}
+          {%- if depth == 2 -%}
+            {%- unless visited_urls contains page.url -%}
               <div>
                 <a class="mobile-header" href="{{ page.url}}">{{ page.title }}</a><button class="accordion"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M480-345 240-585l56-56 184 184 184-184 56 56-240 240Z"/></svg></button>
                 <div class="panel">
-                  {% assign visited_urls = visited_urls | append: page.url | append: "|" %}
-                  {% for level1_page in sorted_pages %}
-                    {% if level1_page.url != '/' %}
-                      {% assign level1_segments = level1_page.url | split: '/' %}
-                      {% if level1_segments[1] == segments[1] and level1_segments | size == 3 %}
-                        {% unless visited_urls contains level1_page.url %}
+                  {%- assign visited_urls = visited_urls | append: page.url | append: "|" -%}
+                  {%- for level1_page in sorted_pages -%}
+                    {%- if level1_page.url != '/' -%}
+                      {%- assign level1_segments = level1_page.url | split: '/' -%}
+                      {%- if level1_segments[1] == segments[1] and level1_segments | size == 3 -%}
+                        {%- unless visited_urls contains level1_page.url -%}
                           <div class="mobile-submenu">
                             <a href="{{ level1_page.url }}">{{ level1_page.title }}</a>
-                            {% assign visited_urls = visited_urls | append: level1_page.url | append: "|" %}
+                            {%- assign visited_urls = visited_urls | append: level1_page.url | append: "|" -%}
                             <ul>
-                              {% for level2_page in sorted_pages %}
-                                {% if level2_page.url != '/' %}
-                                  {% assign level2_segments = level2_page.url | split: '/' %}
-                                  {% if level2_segments[1] == segments[1] and level2_segments[2] == level1_segments[2] and level2_segments | size == 4 %}
-                                    {% unless visited_urls contains level2_page.url %}
+                              {%- for level2_page in sorted_pages -%}
+                                {%- if level2_page.url != '/' -%}
+                                  {%- assign level2_segments = level2_page.url | split: '/' -%}
+                                  {%- if level2_segments[1] == segments[1] and level2_segments[2] == level1_segments[2] and level2_segments | size == 4 -%}
+                                    {%- unless visited_urls contains level2_page.url -%}
                                       <li><a href="{{ level2_page.url }}">{{ level2_page.title }}</a></li>
-                                      {% assign visited_urls = visited_urls | append: level2_page.url | append: "|" %}
+                                      {%- assign visited_urls = visited_urls | append: level2_page.url | append: "|" -%}
                                       <ul>
-                                        {% for level3_page in sorted_pages %}
-                                          {% if level3_page.url != '/' %}
-                                            {% assign level3_segments = level3_page.url | split: '/' %}
-                                            {% if level3_segments[1] == segments[1] and level3_segments[2] == level1_segments[2] and level3_segments[3] == level2_segments[3] and level3_segments | size == 5 %}
-                                              {% unless visited_urls contains level3_page.url %}
+                                        {%- for level3_page in sorted_pages -%}
+                                          {%- if level3_page.url != '/' -%}
+                                            {%- assign level3_segments = level3_page.url | split: '/' -%}
+                                            {%- if level3_segments[1] == segments[1] and level3_segments[2] == level1_segments[2] and level3_segments[3] == level2_segments[3] and level3_segments | size == 5 -%}
+                                              {%- unless visited_urls contains level3_page.url -%}
                                                 <li><a href="{{ level3_page.url }}">{{ level3_page.title }}</a></li>
-                                                {% assign visited_urls = visited_urls | append: level3_page.url | append: "|" %}
-                                                {% comment %} Add another level here {%endcomment%}
-                                              {% endunless %}
-                                            {% endif %}
-                                          {% endif %}
-                                        {% endfor %}
+                                                {%- assign visited_urls = visited_urls | append: level3_page.url | append: "|" -%}
+                                                {%- comment -%} Add another level here {%-endcomment-%}
+                                              {%- endunless -%}
+                                            {%- endif -%}
+                                          {%- endif -%}
+                                        {%- endfor -%}
                                       </ul>
-                                    {% endunless %}
-                                  {% endif %}
-                                {% endif %}
-                              {% endfor %}
+                                    {%- endunless -%}
+                                  {%- endif -%}
+                                {%- endif -%}
+                              {%- endfor -%}
                             </ul>
                           </div>
-                        {% endunless %}
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
+                        {%- endunless -%}
+                      {%- endif -%}
+                    {%- endif -%}
+                  {%- endfor -%}
                 </div>
               </div>
-            {% endunless %}
-          {% endif %}
-        {% endif %}
-      {% endif %}
-    {% endfor %}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
   </div>
   
-  {% comment %}
+  {%- comment -%}
   
   Diese Komponente unterstützt 4 Ordnungs-Ebenen "out of the box". Sie ist damit in der Lage, einen folgenden Baum korrekt
   abzubilden. | This components supports 4 nesting levels out of the box. It is therefore capable displaying the following
@@ -75,17 +75,17 @@
   see the comment "Add nesting here" and add the following code to expand the code by another level.
   
   <ul>
-    {% for level4_page in sorted_pages %}
-      {% if level4_page.url != '/' %}
-        {% assign level4_segments = level4_page.url | split: '/' %}
-        {% if level4_segments[1] == segments[1] and level4_segments[2] == level1_segments[2] and level4_segments[3] == level2_segments[3] and level4_segments[4] == level3_segments[4] and level4_segments | size == 6 %}
-          {% unless visited_urls contains level4_page.url %}
+    {%- for level4_page in sorted_pages -%}
+      {%- if level4_page.url != '/' -%}
+        {%- assign level4_segments = level4_page.url | split: '/' -%}
+        {%- if level4_segments[1] == segments[1] and level4_segments[2] == level1_segments[2] and level4_segments[3] == level2_segments[3] and level4_segments[4] == level3_segments[4] and level4_segments | size == 6 -%}
+          {%- unless visited_urls contains level4_page.url -%}
             <li><a href="{{ level4_page.url }}">{{ level4_page.title }}</a></li>
-            {% assign visited_urls = visited_urls | append: level4_page.url | append: "|" %}
-          {% endunless %}
-        {% endif %}
-      {% endif %}
-    {% endfor %}
+            {%- assign visited_urls = visited_urls | append: level4_page.url | append: "|" -%}
+          {%- endunless -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
   </ul>
   
-  {% endcomment%}
+  {%- endcomment-%}

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,72 +1,72 @@
 <div class="navbar-nav">
-  {% assign visited_urls = "" %}
-  {% assign sorted_pages = site.pages | where_exp: "item", "item.dir != '/'" | sort: 'order' %}
-  {% for page in sorted_pages %}
-  {% if page.order %}
-    {% if page.url != '/' %}
-      {% assign segments = page.url | split: '/' %}
-      {% assign depth = segments | size %}
-      {% if depth == 2 %}
-        {% unless visited_urls contains page.url %}
+  {%- assign visited_urls = "" -%}
+  {%- assign sorted_pages = site.pages | where_exp: "item", "item.dir != '/'" | sort: 'order' -%}
+  {%- for page in sorted_pages -%}
+  {%- if page.order -%}
+    {%- if page.url != '/' -%}
+      {%- assign segments = page.url | split: '/' -%}
+      {%- assign depth = segments | size -%}
+      {%- if depth == 2 -%}
+        {%- unless visited_urls contains page.url -%}
           <div class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" id="navbarDropdown{{ forloop.index }}" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" href="{{ page.url }}">{{ page.title }}</a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown{{ forloop.index }}">
-              {% assign visited_urls = visited_urls | append: page.url | append: "|" %}
-              {% for level_1_page in sorted_pages %}
-                {% if level_1_page.url != '/' %}
-                  {% assign level_1_segments = level_1_page.url | split: '/' %}
-                  {% if level_1_segments[1] == segments[1] and level_1_segments | size == 3 %}
-                    {% unless visited_urls contains level_1_page.url %}
+              {%- assign visited_urls = visited_urls | append: page.url | append: "|" -%}
+              {%- for level_1_page in sorted_pages -%}
+                {%- if level_1_page.url != '/' -%}
+                  {%- assign level_1_segments = level_1_page.url | split: '/' -%}
+                  {%- if level_1_segments[1] == segments[1] and level_1_segments | size == 3 -%}
+                    {%- unless visited_urls contains level_1_page.url -%}
                       <div>
                         <a class="dropdown-item" href="{{ level_1_page.url }}">{{ level_1_page.title }}</a>
                         <div class="submenu">
                           <ul>
-                            {% assign visited_urls = visited_urls | append: level_1_page.url | append: "|" %}
-                            {% for level_2_page in sorted_pages %}
-                              {% if level_2_page.url != '/' %}
-                                {% assign level_2_segments = level_2_page.url | split: '/' %}
-                                {% if level_2_segments[1] == segments[1] and level_2_segments[2] == level_1_segments[2] and level_2_segments | size == 4 %}
-                                  {% unless visited_urls contains level_2_page.url %}
+                            {%- assign visited_urls = visited_urls | append: level_1_page.url | append: "|" -%}
+                            {%- for level_2_page in sorted_pages -%}
+                              {%- if level_2_page.url != '/' -%}
+                                {%- assign level_2_segments = level_2_page.url | split: '/' -%}
+                                {%- if level_2_segments[1] == segments[1] and level_2_segments[2] == level_1_segments[2] and level_2_segments | size == 4 -%}
+                                  {%- unless visited_urls contains level_2_page.url -%}
                                     <li>
                                       <a href="{{ level_2_page.url }}">{{ level_2_page.title }}</a>
                                       <ul>
-                                        {% assign visited_urls = visited_urls | append: level_2_page.url | append: "|" %}
-                                        {% for level_3_page in sorted_pages %}
-                                          {% if level_3_page.url != '/' %}
-                                            {% assign level_3_segments = level_3_page.url | split: '/' %}
-                                            {% if level_3_segments[1] == segments[1] and level_3_segments[2] == level_1_segments[2] and level_3_segments[3] == level_2_segments[3] and level_3_segments | size == 5 %}
-                                              {% unless visited_urls contains level_3_page.url %}
+                                        {%- assign visited_urls = visited_urls | append: level_2_page.url | append: "|" -%}
+                                        {%- for level_3_page in sorted_pages -%}
+                                          {%- if level_3_page.url != '/' -%}
+                                            {%- assign level_3_segments = level_3_page.url | split: '/' -%}
+                                            {%- if level_3_segments[1] == segments[1] and level_3_segments[2] == level_1_segments[2] and level_3_segments[3] == level_2_segments[3] and level_3_segments | size == 5 -%}
+                                              {%- unless visited_urls contains level_3_page.url -%}
                                                 <li>
                                                   <a href="{{ level_3_page.url }}">{{ level_3_page.title }}</a>
                                                 </li>
-                                                {% assign visited_urls = visited_urls | append: level_3_page.url | append: "|" %}
-                                              {% endunless %}
-                                            {% endif %}
-                                          {% endif %}
-                                        {% endfor %}
+                                                {%- assign visited_urls = visited_urls | append: level_3_page.url | append: "|" -%}
+                                              {%- endunless -%}
+                                            {%- endif -%}
+                                          {%- endif -%}
+                                        {%- endfor -%}
                                       </ul>
                                     </li>
-                                  {% endunless %}
-                                {% endif %}
-                              {% endif %}
-                            {% endfor %}
+                                  {%- endunless -%}
+                                {%- endif -%}
+                              {%- endif -%}
+                            {%- endfor -%}
                           </ul>
                         </div>
                       </div>
-                    {% endunless %}
-                  {% endif %}
-                {% endif %}
-              {% endfor %}
+                    {%- endunless -%}
+                  {%- endif -%}
+                {%- endif -%}
+              {%- endfor -%}
             </div>
           </div>
-        {% endunless %}
-      {% endif %}
-    {% endif %}
-    {% endif %}
-  {% endfor %}
+        {%- endunless -%}
+      {%- endif -%}
+    {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
 </div>
 
-{% comment %}
+{%- comment -%}
 
 Diese Komponente unterstützt 4 Ordnungs-Ebenen "out of the box". Sie ist damit in der Lage, einen folgenden Baum korrekt
 abzubilden. | This components supports 4 nesting levels out of the box. It is therefore capable displaying the following
@@ -75,4 +75,4 @@ tree.
 [Startseite >] Seite (Dropdown) > Level-1-Seite > Level-2-Seite > Level-3-Seite |
 [Home >] page (Dropdown) > Level 1 page > level 2 page > level 3 page
 
-{% endcomment%}
+{%- endcomment -%}


### PR DESCRIPTION
In the breadcrumbs.html, the mobile-navigation.html, and the navigation.html "{%" and "%}" were replaced with  "{%-" and "-%}" for cleaning the empty lines in the generated html. Also: unnecessary line breaks in the code where removed.